### PR TITLE
Add optional setting - Show title of video as an XBMC notification

### DIFF
--- a/default.py
+++ b/default.py
@@ -7,6 +7,8 @@ pluginhandle = int(sys.argv[1])
 xbox = xbmc.getCondVisibility("System.Platform.xbox")
 addon = xbmcaddon.Addon(id='plugin.video.bestofyoutube_com')
 translation = addon.getLocalizedString
+icon = addon.getAddonInfo('icon')
+addonname = addon.getAddonInfo('name')
 
 forceViewMode=addon.getSetting("forceViewMode")
 if forceViewMode=="true":
@@ -52,7 +54,7 @@ def playVideo(id, name):
         if titleNotify=="true":
             xbmc.sleep(5000)
             if xbmc.Player().isPlaying():
-                xbmc.executebuiltin('XBMC.Notification("Best Of Youtube", %s)' % name) 
+                xbmc.executebuiltin('XBMC.Notification(%s, %s, 5000, %s)' % (addonname, name, icon))
 
 def listLatest():
         content = getUrl("http://feeds.feedburner.com/bestofyoutubedotcom")

--- a/default.py
+++ b/default.py
@@ -40,13 +40,19 @@ def search():
           search_string = keyboard.getText().replace(" ","+")
           listVideos("http://www.bestofyoutube.com/search.php?q="+search_string)
 
-def playVideo(id):
+def playVideo(id, name):
         if xbox==True:
           url = "plugin://video/YouTube/?path=/root/video&action=play_video&videoid=" + id
         else:
           url = "plugin://plugin.video.youtube/?path=/root/video&action=play_video&videoid=" + id
         listitem = xbmcgui.ListItem(path=url)
-        return xbmcplugin.setResolvedUrl(pluginhandle, True, listitem)
+        xbmcplugin.setResolvedUrl(pluginhandle, True, listitem)
+        
+        titleNotify=addon.getSetting("titleNotify")
+        if titleNotify=="true":
+            xbmc.sleep(5000)
+            if xbmc.Player().isPlaying():
+                xbmc.executebuiltin('XBMC.Notification("Best Of Youtube", %s)' % name) 
 
 def listLatest():
         content = getUrl("http://feeds.feedburner.com/bestofyoutubedotcom")
@@ -105,7 +111,7 @@ def cleanTitle(title):
         return title
 
 def addLink(name,url,mode,iconimage):
-        u=sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+str(mode)
+        u=sys.argv[0]+"?url="+urllib.quote_plus(url)+"&mode="+str(mode)+"&name="+urllib.quote_plus(name)
         ok=True
         liz=xbmcgui.ListItem(name, iconImage="DefaultVideo.png", thumbnailImage=iconimage)
         liz.setInfo( type="Video", infoLabels={ "Title": name } )
@@ -143,7 +149,8 @@ if mode == 'listVideos':
 elif mode == 'listLatest':
     listLatest()
 elif mode == 'playVideo':
-    playVideo(url)
+    name=urllib.unquote_plus(params.get('name'))
+    playVideo(url, name)
 elif mode == 'bestOf':
     bestOf()
 elif mode == 'search':

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -11,4 +11,5 @@
   <string id="30009">Next Page</string>
   <string id="30101">Force View</string>
   <string id="30102">ViewID</string>
+  <string id="30103">Show video title as notification</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,4 +1,5 @@
 <settings>
    <setting id="forceViewMode" type="bool" label="30101" default="false"/>
    <setting id="viewMode" type="number" label="30102" default="500"/>
+   <setting id="titleNotify" type="bool" label="30103" default="false"/>
 </settings>


### PR DESCRIPTION
I regularly use the "Play from here" option to play the latest videos from Best Of. One problem with doing that is that you usually don't know what the title of each video is, in some cases you need to know what the title is in order to understand what your seeing.

This pull request adds a setting that shows the video title in an XBMC notification a few seconds after the video has started.
