### PR TITLE
Optionally filter out crap videos, based on votes

### DIFF
--- a/default.py
+++ b/default.py
@@ -14,6 +14,8 @@ if forceViewMode=="true":
 else:
   forceViewMode=False
 viewMode=str(addon.getSetting("viewMode"))
+filterScore=int(addon.getSetting("filterScore"))
+filterVoteThreshold=int(addon.getSetting("filterVoteThreshold"))
 
 def index():
         addDir(translation(30001),"http://www.bestofyoutube.com","listVideos","")
@@ -76,6 +78,10 @@ def listVideos(url):
               percentage=int((up/(up+down))*100)
             else:
               percentage=100
+            
+            if (up+down)>filterVoteThreshold and percentage<filterScore:
+                continue
+            
             title=title+" ("+str(percentage)+"%)"
             addLink(title,id,"playVideo",thumb)
         content=content[content.find('<div class="pagination">'):]

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -11,4 +11,6 @@
   <string id="30009">Next Page</string>
   <string id="30101">Force View</string>
   <string id="30102">ViewID</string>
+  <string id="30104">Filter out videos with a score lower than</string>
+  <string id="30105">Minimum number of votes for filter</string>
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,4 +1,6 @@
 <settings>
    <setting id="forceViewMode" type="bool" label="30101" default="false"/>
    <setting id="viewMode" type="number" label="30102" default="500"/>
+   <setting id="filterScore" type="number" label="30104" default="0"/>
+   <setting id="filterVoteThreshold" type="number" label="30105" default="10"/>
 </settings>


### PR DESCRIPTION
A certain number of videos in Best Of are crap, as show by low scores from viewer votes. When watching via "Play from here" it'd be handy to skip videos that fall below a user specified score.

This change achieves that by allowing the user to specify a minimum score and a vote threshold. Any video with more votes than the vote threshold AND a score less than the score minimum will not be listed.

The vote threshold is necessary because a video just a handful of votes won't always have a score that's representative of what people think of it. 

The default vote threshold is 10.
The default score minimum is 0, i.e. by default all videos are listed.
