### PR TITLE
Fixed ID parsing bug that broke the plugin... 

### DIFF
--- a/default.py
+++ b/default.py
@@ -57,7 +57,7 @@ def listVideos(url):
     spl = content.split("<div class='main'>")
     for i in range(1, len(spl), 1):
         entry = spl[i]
-        match = re.compile('youtube.com/embed/(.+?)\?', re.DOTALL).findall(entry)
+        match = re.compile('youtube.com/embed/(.+?)[?"]', re.DOTALL).findall(entry)
         id = match[0]
         match = re.compile("name='up'>(.+?)<", re.DOTALL).findall(entry)
         up = float(match[0])


### PR DESCRIPTION
... when the embed URLs stopped using query strings.

This change tells the script to stop reading in the ID when it finds either a question-mark character or a double-quote character, whichever comes first.  This allows the add-on to work again with BOYT's current HTML markup, which embeds videos like this:

<iframe width="504" height="306" src="//www.youtube.com/embed/KcBS823VTbU" frameborder="0" allowfullscreen></iframe>
